### PR TITLE
Removes cartopy as a dependency

### DIFF
--- a/ci/environment-core-deps.yml
+++ b/ci/environment-core-deps.yml
@@ -9,7 +9,6 @@ dependencies:
   - pytest
   - future
   - matplotlib
-  - cartopy
   - pykdtree
   - opencv
   - pip:

--- a/ci/environment-docs.yml
+++ b/ci/environment-docs.yml
@@ -7,7 +7,6 @@ dependencies:
   # Core
   - xarray
   - matplotlib
-  - cartopy
   - ffmpeg
   # Optional
   - tqdm

--- a/ci/environment.yml
+++ b/ci/environment.yml
@@ -9,7 +9,6 @@ dependencies:
   - pytest
   - future
   - matplotlib
-  - cartopy
   - pykdtree
   - ffmpeg
   - tqdm

--- a/xmovie/__init__.py
+++ b/xmovie/__init__.py
@@ -1,5 +1,5 @@
 from .core import Movie
-from .presets import rotating_globe
+from .presets import basic
 
 try:
     from ._version import __version__

--- a/xmovie/presets.py
+++ b/xmovie/presets.py
@@ -134,7 +134,6 @@ def _set_style(fig, ax, pp, style):
         plt.setp(plt.getp(cb.ax.axes, "yticklabels"), color=fgcolor)
 
 
-
 # Presets (should proabably put all others into a submodule)
 
 
@@ -148,5 +147,3 @@ def basic(
     data = _check_input(da, plot_variable)
     pp = _base_plot(ax, data, timestamp, framedim, plotmethod=plotmethod, **kwargs)
     return ax, pp
-
-

--- a/xmovie/presets.py
+++ b/xmovie/presets.py
@@ -1,13 +1,10 @@
 import warnings
 
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
 import matplotlib.pyplot as plt
 import matplotlib.ticker as mticker
 import numpy as np
 import shapely.geometry as sgeom
 import xarray as xr
-from cartopy.mpl import geoaxes
 
 
 def _check_input(da, fieldname):
@@ -68,41 +65,6 @@ def _base_plot(ax, base_data, timestamp, framedim, plotmethod=None, **kwargs):
     return p
 
 
-# projections utilities and hacks
-def _smooth_boundary_NearsidePerspective(projection):
-    # workaround for a smoother outer boundary
-    # (https://github.com/SciTools/cartopy/issues/613)
-    # Re-implement the cartopy code to figure out the boundary.
-
-    # This is just really a guess....
-    WGS84_SEMIMAJOR_AXIS = 6378137.0
-    # because I cannot import it above...this should be fixed upstream
-    # anyways...
-
-    a = projection.globe.semimajor_axis or WGS84_SEMIMAJOR_AXIS
-    h = projection.proj4_params["h"]
-    false_easting = projection.proj4_params["x_0"]
-    false_northing = projection.proj4_params["y_0"]
-    max_x = a * np.sqrt(h / (2 * a + h))
-    coords = ccrs._ellipse_boundary(max_x, max_x, false_easting, false_northing, n=361)
-    projection._boundary = sgeom.LinearRing(coords.T)
-    return projection
-
-
-# def _smooth_boundary_globe(projection):
-#     # workaround for a smoother outer boundary
-#     # (https://github.com/SciTools/cartopy/issues/613)
-#
-#     # Re-implement the cartopy code to figure out the boundary.
-#     a = np.float(projection.globe.semimajor_axis or 6378137.0)
-#     b = np.float(projection.globe.semiminor_axis or a)
-#     coords = ccrs._ellipse_boundary(a * 0.99999, b * 0.99999, n=361)
-#
-#     # Update the projection's boundary.
-#     projection._boundary = sgeom.polygon.LinearRing(coords.T)
-#     return projection
-
-
 # Styling of the plot elements
 def _style_dict_raw():
     return {
@@ -134,10 +96,6 @@ def _style_dict(style=None):
 
 def _set_style(fig, ax, pp, style):
     "Sets the colorscheme for figure, axis and plot object (`pp`) according to style"
-    # check if ax is 'normal' or cartopy projection
-    is_geoax = False
-    if isinstance(ax, geoaxes.GeoAxesSubplot):
-        is_geoax = True
 
     # parse styles
     style_dict = _style_dict(style)
@@ -154,17 +112,7 @@ def _set_style(fig, ax, pp, style):
     blend_outline_patch = style_dict.pop("blend_outline_patch", None)
 
     fig.patch.set_facecolor(bgcolor)
-    if is_geoax:
-        ax.patch.set_facecolor(bgcolor)
-    else:
-        ax.set_facecolor(bgcolor)
-
-    # Use the boundary to blend the edges of the globe into background
-    if blend_outline_patch:
-        if is_geoax:
-            ax.outline_patch.set_edgecolor(bgcolor)
-            ax.outline_patch.set_antialiased(True)
-            ax.outline_patch.set_linewidth(2)
+    ax.set_facecolor(bgcolor)
 
     # modify colorbar
     try:
@@ -186,29 +134,6 @@ def _set_style(fig, ax, pp, style):
         plt.setp(plt.getp(cb.ax.axes, "yticklabels"), color=fgcolor)
 
 
-def _add_land(ax, style):
-    if not isinstance(ax, geoaxes.GeoAxesSubplot):
-        raise ValueError("Cannot add land on non-cartopy axes. Got ($s)" % type(ax))
-    style_dict = _style_dict(style)
-    feature = cfeature.NaturalEarthFeature(
-        name="land", category="physical", scale="50m", facecolor=style_dict["landcolor"]
-    )
-    ax.add_feature(feature)
-
-
-def _add_coast(ax, style):
-    if not isinstance(ax, geoaxes.GeoAxesSubplot):
-        raise ValueError("Cannot add land on non-cartopy axes. Got ($s)" % type(ax))
-    style_dict = _style_dict(style)
-    feature = cfeature.NaturalEarthFeature(
-        name="coastline",
-        category="physical",
-        scale="50m",
-        edgecolor=style_dict["coastcolor"],
-        facecolor="none",
-    )
-    ax.add_feature(feature)
-
 
 # Presets (should proabably put all others into a submodule)
 
@@ -225,122 +150,3 @@ def basic(
     return ax, pp
 
 
-def rotating_globe(
-    da,
-    fig,
-    timestamp,
-    framedim="time",
-    plotmethod=None,
-    plot_variable=None,
-    overlay_variables=None,
-    lon_start=-110,
-    lon_rotations=0.5,
-    lat_start=25,
-    lat_rotations=0,
-    land=False,
-    gridlines=False,
-    coastline=True,
-    style=None,
-    debug=False,
-    **kwargs
-):
-    """
-    Rotating globe plot.
-
-    Parameters
-    ----------
-    da : DataArray
-        Data to be plotted.
-    fig : Figure
-        Figure to plot on.
-    timestamp : int
-        Used to select the animation frame using :meth:`~xarray.DataArray.isel`
-        with dimension `framedim`.
-    framedim : str
-        Dimension name along which frames will be generated.
-    plotmethod : str, optional
-        Method of :attr:`xarray.DataArray.plot` to use.
-    plot_variable : str, optional
-        Variable to plot. Not needed for :class:`~xarray.DataArray`.
-    overlay_variables
-        Currently unused.
-    lon_start : float
-        Central longitude at the beginning of the animation.
-    lon_rotations : float
-        Number of longitude rotations to be completed in the animation.
-    lat_start : float
-        As in `lon_start`.
-    lat_rotations : float
-        As in `lon_rotations`.
-    land : bool
-        Plot the land.
-    gridlines : bool
-        Plot lat/lon gridlines.
-    coastline : bool
-        Plot the coastlines.
-    style : {'standard', 'dark'}
-    debug : bool
-        Currently unused.
-    **kwargs
-        Passed on to the xarray plotting method.
-    """
-
-    # rotate lon_rotations times throughout movie and start at lon_start
-    lon = np.linspace(0, 360 * lon_rotations, len(da[framedim])) + lon_start
-    # Same for lat
-    lat = np.linspace(0, 360 * lat_rotations, len(da[framedim])) + lat_start
-
-    # proj = ccrs.Orthographic(lon[timestamp], lat[timestamp])
-    # proj = _smooth_boundary_globe(proj)
-    # This looks more like a 3D globe in my opinion
-    proj = ccrs.NearsidePerspective(central_longitude=lon[timestamp], central_latitude=lat[timestamp])
-    proj = _smooth_boundary_NearsidePerspective(proj)
-
-    subplot_kw = dict(projection=proj)
-
-    # mapping style kwargs
-    map_style_kwargs = dict(transform=ccrs.PlateCarree())
-    kwargs.update(map_style_kwargs)
-
-    # create axis (TODO:this should be handled by the basic preset )
-    ax = fig.subplots(subplot_kw=subplot_kw)
-    data = _check_input(da, plot_variable)
-    pp = _base_plot(ax, data, timestamp, framedim, plotmethod=plotmethod, **kwargs)
-
-    _set_style(fig, ax, pp, style=style)
-
-    ax.set_title("")
-    ax.set_global()
-
-    # set style (TODO: move this to the basic function including the set style)
-    if land:
-        _add_land(ax, style)
-
-    if coastline:
-        _add_coast(ax, style)
-
-    if gridlines:
-        gl = ax.gridlines()
-        # Increase gridline res
-        gl.n_steps = 500
-        # for now fixed locations
-        gl.xlocator = mticker.FixedLocator(range(-180, 181, 30))
-        gl.ylocator = mticker.FixedLocator(range(-90, 91, 30))
-    else:
-        gl = None
-    # i should output this to test the preset. Maybe a dict output for the pp and gl (and potentially others)?
-
-    # need a way to do that for the outline too
-
-    # possibly for future versions, but I need a way to increase results
-    # ax.outline_patch.set_visible(False)
-    return ax, pp
-
-
-def rotating_globe_dark(da, fig, timestamp, **kwargs):
-    warnings.warn(
-        "This preset will be deprecated in the future. \
-    Use `rotating_globe` with `style=`dark`` instead`",
-        DeprecationWarning,
-    )
-    return rotating_globe(da, fig, timestamp, style="dark", **kwargs)

--- a/xmovie/test/test_presets.py
+++ b/xmovie/test/test_presets.py
@@ -42,19 +42,3 @@ def test_core_plot(plotmethod, expected_type, filled):
     if filled is not None:
         assert pp.filled == filled
 
-
-@pytest.mark.parametrize("lon", [-700, -300, 1, 300, 700])
-@pytest.mark.parametrize("lat", [-200, -90, 0, 90, 180])
-@pytest.mark.parametrize("sat_height", [35785831, 45785831])
-def test_smooth_boundary_NearsidePerspective(lon, lat, sat_height):
-    lon = -100
-    lat = -40
-    sat_height = 35785831
-    pr = ccrs.NearsidePerspective(
-        central_longitude=lon, central_latitude=lat, satellite_height=sat_height
-    )
-    # modify the projection with smooth boundary
-    pr_mod = _smooth_boundary_NearsidePerspective(pr)
-
-    assert pr.proj4_params == pr_mod.proj4_params
-    assert pr.globe == pr_mod.globe

--- a/xmovie/test/test_presets.py
+++ b/xmovie/test/test_presets.py
@@ -41,4 +41,3 @@ def test_core_plot(plotmethod, expected_type, filled):
     assert isinstance(pp, expected_type)
     if filled is not None:
         assert pp.filled == filled
-


### PR DESCRIPTION
More than once I ran into problems installing xmovie because of problems installing cartopy. Since cartopy isn't really needed for xmovie to function, this PR removes it. This also removes the `rotating_globe` preset, which was the only thing that used cartopy.